### PR TITLE
Fix: check `type` is found in cache before using it

### DIFF
--- a/utils/analytics.js
+++ b/utils/analytics.js
@@ -97,8 +97,8 @@ function parseEntries(data, range) {
                 (t) => t === type
             )
 
-            const values = [...timeseries.series[index]['data']]
             if (index > -1 && day) {
+                const values = [...timeseries.series[index]['data']]
                 values[day - 1]++
                 timeseries.series[index]['data'] = values
             }


### PR DESCRIPTION
As found in #1, there are `type`s that may not be found (such as `rsvp`)
which leads to an error when we're using `index` even though it's `-1`.

We can reorder the check to after the use.

Closes #1.