### PR TITLE
Fix for mobile devices

### DIFF
--- a/src/assets/styles/components/_report.scss
+++ b/src/assets/styles/components/_report.scss
@@ -47,6 +47,7 @@
     &__item {
         display: flex;
         flex-direction: column;
+        min-width: 100%;
 
         &--fullwidth {
             grid-column: 1 / -1;

--- a/src/assets/styles/components/_table.scss
+++ b/src/assets/styles/components/_table.scss
@@ -15,6 +15,13 @@
         .icon {
             margin-right: 0.25rem;
         }
+
+        a {
+            white-space: unset;
+            overflow-wrap: break-word;
+            word-wrap: break-word; 
+            word-break: break-word;
+        }
     }
 
     td:first-child,

--- a/src/assets/styles/components/_tweetlist.scss
+++ b/src/assets/styles/components/_tweetlist.scss
@@ -2,4 +2,16 @@
     &__item + &__item {
         margin-top: 2rem;
     }
+
+    a {
+        overflow-wrap: break-word;
+        word-wrap: break-word; 
+        word-break: break-word;
+    }
+}
+
+twitterwidget::shadow .EmbeddedTweet {
+    width: 100% !important;
+    max-width: 100% !important;
+    min-width: 100% !important;
 }

--- a/src/data/meta.json
+++ b/src/data/meta.json
@@ -4,5 +4,6 @@
     "url": "https://webmentions.mxb.dev",
     "domain": "mxb.dev",
     "lang": "en",
-    "locale": "en_us"
+    "locale": "en_us",
+    "theme": "dark"
 }

--- a/src/includes/widgets/tweets.njk
+++ b/src/includes/widgets/tweets.njk
@@ -5,7 +5,7 @@
         {% for tweet in report.data.tweets|slice(0, 4) %}
             {% set tweeturl = tweet.urls|commonURLs|first %}
             <li class="tweetlist__item">
-                <blockquote class="twitter-tweet" data-theme="dark">
+                <blockquote class="twitter-tweet" data-theme="{{ meta.theme }}">
                     <a href="{{ tweeturl }}">{{ tweeturl }}</a>
                 </blockquote> 
             </li>


### PR DESCRIPTION
Twitter widgets with max-width: 550px prevented complete page to increase below 550px. On mobile devices e.g. Pixel 6 with max-width 412px last 138 pixels were hidden.
&
Introducing meta variable for Twitter Theme